### PR TITLE
Adds `convert_migration_id` to ResourceMapService

### DIFF
--- a/lib/canvas_link_migrator/resource_map_service.rb
+++ b/lib/canvas_link_migrator/resource_map_service.rb
@@ -74,7 +74,14 @@ module CanvasLinkMigrator
 
     # looks up a discussion topic
     def convert_discussion_topic_migration_id(migration_id)
-      resources.dig("discussion_topics", migration_id, "destination", "id")
+      dt_id = resources.dig("discussion_topics", migration_id, "destination", "id")
+      # the /discusson_topic url scheme is used for annnouncments as well. We'll
+      # check both here
+      dt_id || convert_announcement_migration_id(migration_id)
+    end
+
+    def convert_announcement_migration_id(migration_id)
+      resources.dig("announcements", migration_id, "destination", "id")
     end
 
     def convert_context_module_tag_migration_id(migration_id)

--- a/lib/canvas_link_migrator/resource_map_service.rb
+++ b/lib/canvas_link_migrator/resource_map_service.rb
@@ -84,5 +84,11 @@ module CanvasLinkMigrator
     def convert_attachment_migration_id(migration_id)
       resources.dig("files", migration_id, "destination", "id")
     end
+
+    def convert_migration_id(type, migration_id)
+      if LinkParser::KNOWN_REFERENCE_TYPES.include? type
+        resources.dig(type, migration_id, "destination", "id")
+      end
+    end
   end
 end


### PR DESCRIPTION
LinkResolver relies on the migration_id_convertere to implement a convert_migration_id method to handle
fallback cases where the link type is not specifically handled.

It's likely the resource map wont actually have any... but this at least adds future proofing and flexibility if we need to add new link types in the future.