### PR TITLE
Resolve wiki links with migration id

### DIFF
--- a/lib/canvas_link_migrator/link_parser.rb
+++ b/lib/canvas_link_migrator/link_parser.rb
@@ -181,8 +181,8 @@ module CanvasLinkMigrator
 
     # returns a hash with resolution status and data to hold onto if unresolved
     def parse_url(url, node, attr)
-      if url =~ /wiki_page_migration_id=([^?]*)(\?.*)?/
-        unresolved(:wiki_page, migration_id: $1, query: $2)
+      if url =~ /wiki_page_migration_id=(.*)/
+        unresolved(:wiki_page, migration_id: $1)
       elsif url =~ /discussion_topic_migration_id=(.*)/
         unresolved(:discussion_topic, migration_id: $1)
       elsif url =~ %r{\$CANVAS_COURSE_REFERENCE\$/modules/items/([^?]*)(\?.*)?}

--- a/lib/canvas_link_migrator/link_resolver.rb
+++ b/lib/canvas_link_migrator/link_resolver.rb
@@ -68,7 +68,8 @@ module CanvasLinkMigrator
         type = "pages" if type == "wiki"
         if type == "pages"
           query = resolve_module_item_query(nil, link[:query])
-          link[:new_value] = "#{context_path}/pages/#{migration_id}#{query}"
+          linked_wiki_url = @migration_id_converter.convert_wiki_page_migration_id_to_slug(migration_id) || migration_id
+          link[:new_value] = "#{context_path}/pages/#{linked_wiki_url}#{query}"
         elsif type == "attachments"
           att_id = @migration_id_converter.convert_attachment_migration_id(migration_id)
           if att_id

--- a/spec/canvas_link_migrator/imported_html_converter_spec.rb
+++ b/spec/canvas_link_migrator/imported_html_converter_spec.rb
@@ -37,6 +37,13 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
       expect(bad_links).to be_nil
     end
 
+    it "converts a wiki reference with migration id" do
+      test_string = %(<a href="%24WIKI_REFERENCE%24/wiki/A?query=blah">Test Wiki Page</a>)
+      html, bad_links = @converter.convert_exported_html(test_string)
+      expect(html).to eq %(<a href="#{@path}pages/slug-a?query=blah">Test Wiki Page</a>)
+      expect(bad_links).to be_nil
+    end
+
     context "when course attachments exist" do
       subject { @converter.convert_exported_html(test_string) }
 
@@ -122,12 +129,6 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
       test_string = %(<a href="wiki_page_migration_id=A">Test Wiki Page</a>)
 
       expect(@converter.convert_exported_html(test_string)).to eq([%(<a href="#{@path}pages/slug-a">Test Wiki Page</a>), nil])
-    end
-
-    it "converts a wiki reference by migration id and includes queries" do
-      test_string = %(<a href="wiki_page_migration_id=A?foo=bar">Test Wiki Page</a>)
-
-      expect(@converter.convert_exported_html(test_string)).to eq([%(<a href="#{@path}pages/slug-a?foo=bar">Test Wiki Page</a>), nil])
     end
 
     it "converts a discussion reference by migration id" do

--- a/spec/canvas_link_migrator/imported_html_converter_spec.rb
+++ b/spec/canvas_link_migrator/imported_html_converter_spec.rb
@@ -38,7 +38,7 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
     end
 
     it "converts a wiki reference with migration id" do
-      test_string = %(<a href="%24WIKI_REFERENCE%24/wiki/A?query=blah">Test Wiki Page</a>)
+      test_string = %(<a href="%24WIKI_REFERENCE%24/pages/A?query=blah">Test Wiki Page</a>)
       html, bad_links = @converter.convert_exported_html(test_string)
       expect(html).to eq %(<a href="#{@path}pages/slug-a?query=blah">Test Wiki Page</a>)
       expect(bad_links).to be_nil


### PR DESCRIPTION
Allows for wiki links with a migration id instead of a page title to be resolved.

refs LF-521
flag=none

Test Plan
- specs pass