### PR TITLE
Handle resource map having pages but not wiki_pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_link_migrator (1.0.3)
+    canvas_link_migrator (1.0.4)
       activesupport
       addressable
       nokogiri

--- a/canvas_link_migrator.gemspec
+++ b/canvas_link_migrator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "canvas_link_migrator"
-  spec.version       = "1.0.3"
+  spec.version       = "1.0.4"
   spec.authors       = ["Mysti Lilla", "James Logan", "Sarah Gerard", "Math Costa"]
   spec.email         = ["mysti@instructure.com", "james.logan@instructure.com", "sarah.gerard@instructure.com", "luis.oliveira@instructure.com"]
   spec.summary       = "Instructure gem for migrating Canvas style rich content"

--- a/lib/canvas_link_migrator/resource_map_service.rb
+++ b/lib/canvas_link_migrator/resource_map_service.rb
@@ -69,7 +69,7 @@ module CanvasLinkMigrator
 
     # Looks up a wiki page slug for a migration id
     def convert_wiki_page_migration_id_to_slug(migration_id)
-      resources.dig("wiki_pages", migration_id, "destination", "url")
+      resources.dig("wiki_pages", migration_id, "destination", "url") || resources.dig("pages", migration_id, "destination", "url")
     end
 
     # looks up a discussion topic

--- a/spec/canvas_link_migrator/imported_html_converter_spec.rb
+++ b/spec/canvas_link_migrator/imported_html_converter_spec.rb
@@ -25,7 +25,7 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
   # tests link_parser and link_resolver
 
   describe ".convert" do
-    before do
+    before(:each) do
       @path = "/courses/2/"
       @converter = CanvasLinkMigrator::ImportedHtmlConverter.new(resource_map: JSON.parse(File.read("spec/fixtures/canvas_resource_map.json")))
     end
@@ -42,6 +42,24 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
       html, bad_links = @converter.convert_exported_html(test_string)
       expect(html).to eq %(<a href="#{@path}pages/slug-a?query=blah">Test Wiki Page</a>)
       expect(bad_links).to be_nil
+    end
+
+    context "when pages in resource map but no wiki_pages" do
+      before(:each) do
+        @converter = CanvasLinkMigrator::ImportedHtmlConverter.new(resource_map: JSON.parse(File.read("spec/fixtures/canvas_resource_map_pages.json")))
+      end
+
+        it "converts a wiki reference with migration id" do
+          test_string = %(<a href="%24WIKI_REFERENCE%24/pages/A?query=blah">Test Wiki Page</a>)
+          html, bad_links = @converter.convert_exported_html(test_string)
+          expect(html).to eq %(<a href="#{@path}pages/slug-a?query=blah">Test Wiki Page</a>)
+          expect(bad_links).to be_nil
+        end
+
+        it "converts a wiki reference by migration id" do
+          test_string = %(<a href="wiki_page_migration_id=A">Test Wiki Page</a>)
+          expect(@converter.convert_exported_html(test_string)).to eq([%(<a href="#{@path}pages/slug-a">Test Wiki Page</a>), nil])
+        end
     end
 
     context "when course attachments exist" do

--- a/spec/canvas_link_migrator/link_resolver_spec.rb
+++ b/spec/canvas_link_migrator/link_resolver_spec.rb
@@ -33,6 +33,12 @@ describe CanvasLinkMigrator::LinkResolver do
       expect(link[:new_value]).to eq("/courses/2/pages/slug-a?foo=bar")
     end
 
+    it "converts wiki_pages links with pages in resource map" do
+      link = { link_type: :wiki_page, migration_id: "A", query: "?foo=bar" }
+      resolver(JSON.parse(File.read("spec/fixtures/canvas_resource_map_pages.json"))).resolve_link!(link)
+      expect(link[:new_value]).to eq("/courses/2/pages/slug-a?foo=bar")
+    end
+
     it "converts module_item links" do
       link = { link_type: :module_item, migration_id: "C", query: "?foo=bar" }
       resolver.resolve_link!(link)

--- a/spec/fixtures/canvas_resource_map_pages.json
+++ b/spec/fixtures/canvas_resource_map_pages.json
@@ -1,0 +1,134 @@
+{
+    "attachment_path_id_lookup": {
+      "subfolder/test.png": "G",
+      "subfolder/with a space/test.png": "F",
+      "subfolder/with a space/yodawg.mov": "I",
+      "subfolder/withCapital/test.png": "migration_id!",
+      "lolcat.mp3": "H",
+      "test.png": "E"
+    },
+    "contains_migration_ids": true,
+    "destination_course": "2",
+    "destination_hosts": [
+      "apple.edu",
+      "kiwi.edu"
+    ],
+    "destination_root_folder": "course files/",
+    "resource_mapping": {
+      "announcements": {
+        "H": {
+          "source": {
+            "id": "9"
+          },
+          "destination": {
+            "id": "10"
+          }
+        }
+      },
+      "assignments": {
+        "I": {
+          "source": {
+            "id": "11"
+          },
+          "destination": {
+            "id": "12"
+          }
+        }
+      },
+      "discussion_topics": {
+        "G": {
+          "destination": {
+            "id": "7"
+          },
+          "source": {
+            "id": "6"
+          }
+        }
+      },
+      "files": {
+        "E": {
+          "destination": {
+            "id": "5",
+            "media_entry_id": "m-stuff"
+          },
+          "source": {
+            "id": "3",
+            "media_entry_id": "m-stuff"
+          }
+        },
+        "F": {
+          "destination": {
+            "id": "6",
+            "media_entry_id": "m-stuff"
+          },
+          "source": {
+            "id": "4",
+            "media_entry_id": "m-stuff"
+          }
+        },
+        "G": {
+          "destination": {
+            "id": "7"
+          },
+          "source": {
+            "id": "2"
+          }
+        },
+        "H": {
+          "destination": {
+            "id": "8",
+            "media_entry_id": "m-lolcat"
+          },
+          "source": {
+            "id": "3",
+            "media_entry_id": "m-lolcat"
+          }
+        },
+        "I": {
+          "destination": {
+            "id": "9",
+            "media_entry_id": "m-yodawg"
+          },
+          "source": {
+            "id": "4",
+            "media_entry_id": "m-yodawg"
+          }
+        }
+      },
+      "module_items": {
+        "C": {
+          "destination": {
+            "id": "3"
+          },
+          "source": {
+            "id": "2"
+          }
+        }
+      },
+      "modules": {
+        "J": {
+          "destination": {
+            "id": "36"
+          },
+          "source": {
+            "id": "22"
+          }
+        }
+      },
+      "pages": {
+        "A": {
+          "destination": {
+            "id": "2",
+            "url": "slug-a"
+          },
+          "source": {
+            "id": "1",
+            "url": "slug-a"
+          }
+        }
+      }
+    },
+    "source_course": "1",
+    "source_host": "pineapple.edu"
+  }
+  


### PR DESCRIPTION
Handle resource map having pages but not wiki_pages

refs LF-1147
flag=none

Test Plan:
-Copy link_migrator changes into NQ
-Have a course with a Classic Quiz that has links to a Page
-Do a course copy, enabling the option to import Classic Quizzes as New Quizzes
*In the new course, verify that the New Quiz Page link is correct.