### PR TITLE
LF-1146

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_link_migrator (1.0.5)
+    canvas_link_migrator (1.0.6)
       activesupport
       addressable
       nokogiri

--- a/lib/canvas_link_migrator/link_resolver.rb
+++ b/lib/canvas_link_migrator/link_resolver.rb
@@ -108,6 +108,8 @@ module CanvasLinkMigrator
       when :file
         rel_path = link[:rel_path]
         new_url = resolve_relative_file_url(rel_path)
+        # leave user urls alone
+        new_url ||= rel_path if is_relative_user_url(rel_path)
         unless new_url
           new_url = missing_relative_file_url(rel_path)
           link[:missing_url] = new_url
@@ -254,6 +256,10 @@ module CanvasLinkMigrator
         node.delete("style")
         nil
       end
+    end
+
+    def is_relative_user_url(rel_path)
+      rel_path.start_with?("/users/")
     end
   end
 end

--- a/lib/canvas_link_migrator/version.rb
+++ b/lib/canvas_link_migrator/version.rb
@@ -1,3 +1,3 @@
 module CanvasLinkMigrator
-  VERSION = "1.0.5"
+  VERSION = "1.0.6"
 end

--- a/spec/canvas_link_migrator/imported_html_converter_spec.rb
+++ b/spec/canvas_link_migrator/imported_html_converter_spec.rb
@@ -87,12 +87,12 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
       end
 
       it "leaves relative user attachments alone" do
-        test_string = %{<p> This is an image: <img src="/users/1/files/1/preview?verifier=2Zn2diT03FhIhPL21GnVkTyebw4FCy62DHM8avI9" alt="some_image"></p>}
+        test_string = %{<p> This is an image: <img src="/users/1/files/1/preview?verifier=someVerifier" alt="some_image"></p>}
         expect(@converter.convert_exported_html(test_string)).to eq([test_string, nil])
       end
 
       it "leaves absolute user attachments alone" do
-        test_string = %{<p> This is an image: <img src="http://mycanvas.com/users/1/files/1/preview?verifier=2Zn2diT03FhIhPL21GnVkTyebw4FCy62DHM8avI9" alt="some_image"></p>}
+        test_string = %{<p> This is an image: <img src="http://mycanvas.com/users/1/files/1/preview?verifier=someVerifier" alt="some_image"></p>}
         expect(@converter.convert_exported_html(test_string)).to eq([test_string, nil])
       end
 

--- a/spec/canvas_link_migrator/imported_html_converter_spec.rb
+++ b/spec/canvas_link_migrator/imported_html_converter_spec.rb
@@ -86,6 +86,16 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
         expect(@converter.convert_exported_html(test_string)).to eq([%{<p>This is an image: <br><img src="#{@path}files/6/preview" alt=":("></p>}, nil])
       end
 
+      it "leaves relative user attachments alone" do
+        test_string = %{<p> This is an image: <img src="/users/1/files/1/preview?verifier=2Zn2diT03FhIhPL21GnVkTyebw4FCy62DHM8avI9" alt="some_image"></p>}
+        expect(@converter.convert_exported_html(test_string)).to eq([test_string, nil])
+      end
+
+      it "leaves absolute user attachments alone" do
+        test_string = %{<p> This is an image: <img src="http://mycanvas.com/users/1/files/1/preview?verifier=2Zn2diT03FhIhPL21GnVkTyebw4FCy62DHM8avI9" alt="some_image"></p>}
+        expect(@converter.convert_exported_html(test_string)).to eq([test_string, nil])
+      end
+
       it "finds an attachment by path" do
         test_string = %{<p>This is an image: <br /><img src="%24IMS_CC_FILEBASE%24/test.png" alt=":(" /></p>}
 


### PR DESCRIPTION
fixes LF-1146
flag=none

Test Plan:
 - Copy canvas_link_migrator changes to NQ
 - Create a classic quiz with links to user stuff (images/files/etc)
 - Copy course to new course, migrating quizzes to NQ
 - Verify user links in the migrated NQ work as expected