### PR TITLE
Change all media in rich content to media_attachments_iframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+**/.DS_Store
 /.config
 /coverage/
 /InstalledFiles

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@
 
 source "https://rubygems.org"
 
+gem "activesupport", "~> 7.0.8"
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_link_migrator (1.0.6)
+    canvas_link_migrator (1.0.7)
       activesupport
       addressable
       nokogiri
@@ -63,6 +63,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (~> 7.0.8)
   bundler
   byebug
   canvas_link_migrator!

--- a/canvas_link_migrator.gemspec
+++ b/canvas_link_migrator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "canvas_link_migrator"
-  spec.version       = "1.0.6"
+  spec.version       = "1.0.7"
   spec.authors       = ["Mysti Lilla", "James Logan", "Sarah Gerard", "Math Costa"]
   spec.email         = ["mysti@instructure.com", "james.logan@instructure.com", "sarah.gerard@instructure.com", "luis.oliveira@instructure.com"]
   spec.summary       = "Instructure gem for migrating Canvas style rich content"

--- a/lib/canvas_link_migrator/resource_map_service.rb
+++ b/lib/canvas_link_migrator/resource_map_service.rb
@@ -106,5 +106,17 @@ module CanvasLinkMigrator
     def lookup_attachment_by_migration_id(migration_id)
       resources.dig("files", migration_id, "destination")
     end
+
+    def media_map
+      @media_map ||= resources["files"].each_with_object({}) do |(_mig_id, file), map|
+        media_id = file.dig("destination", "media_entry_id")
+        next unless media_id
+        map[media_id] = file
+      end
+    end
+
+    def lookup_attachment_by_media_id(media_id)
+      media_map.dig(media_id, "destination")
+    end
   end
 end

--- a/lib/canvas_link_migrator/version.rb
+++ b/lib/canvas_link_migrator/version.rb
@@ -1,3 +1,3 @@
 module CanvasLinkMigrator
-  VERSION = "1.0.6"
+  VERSION = "1.0.7"
 end

--- a/spec/canvas_link_migrator/link_parser_spec.rb
+++ b/spec/canvas_link_migrator/link_parser_spec.rb
@@ -21,11 +21,8 @@
 require "spec_helper"
 
 describe CanvasLinkMigrator::LinkParser do
-  def parser
-    migration_query_service_mock = double()
-    allow(migration_query_service_mock).to receive(:supports_embedded_images).and_return(true)
-    allow(migration_query_service_mock).to receive(:fix_relative_urls?).and_return(true)
-    CanvasLinkMigrator::LinkParser.new(migration_query_service_mock)
+  def parser(assets = JSON.parse(File.read("spec/fixtures/canvas_resource_map.json")))
+    CanvasLinkMigrator::LinkParser.new(CanvasLinkMigrator::ResourceMapService.new(assets))
   end
 
   describe "convert_link" do

--- a/spec/fixtures/canvas_resource_map.json
+++ b/spec/fixtures/canvas_resource_map.json
@@ -5,7 +5,8 @@
     "subfolder/with a space/yodawg.mov": "I",
     "subfolder/withCapital/test.png": "migration_id!",
     "lolcat.mp3": "H",
-    "test.png": "E"
+    "test.png": "E",
+    "media_objects/0_bq09qam2": "F"
   },
   "contains_migration_ids": true,
   "destination_course": "2",
@@ -59,11 +60,11 @@
       "F": {
         "destination": {
           "id": "6",
-          "media_entry_id": "m-stuff"
+          "media_entry_id": "0_bq09qam2"
         },
         "source": {
           "id": "4",
-          "media_entry_id": "m-stuff"
+          "media_entry_id": "0_bq09qam2"
         }
       },
       "G": {


### PR DESCRIPTION
refs LF-203

Test plan
- Test with https://gerrit.instructure.com/c/canvas-lms/+/343251
- In a quiz do the following:
- Set up a standard media iframe
- Set up media that looks like this: 
&lt;p&gt;&lt;a id=&quot;media_comment_m-65LRekaWzXTLCp9PwqaibDkX3C5Jo6Vf&quot; class=&quot;instructure_inline_media_comment video_comment&quot; href=&quot;/media_objects/m-65LRekaWzXTLCp9PwqaibDkX3C5Jo6Vf&quot; data-media_comment_type=&quot;video&quot; data-alt=&quot;&quot;&gt;&lt;/a&gt;&lt;/p&gt; (use your own media id :) )
- Set up a media object that looks like this:
&lt;p&gt;&lt;iframe style=&quot;width: 200px; height: 150px;&quot; title=&quot;Video&quot; data-media-type=&quot;video&quot; src=&quot;/media_objects_iframe/m-65LRekaWzXTLCp9PwqaibDkX3C5Jo6Vf?type=video&amp;amp;embedded=true&quot; allowfullscreen=&quot;allowfullscreen&quot; allow=&quot;fullscreen&quot; data-media-id=&quot;m-65LRekaWzXTLCp9PwqaibDkX3C5Jo6Vf&quot;&gt;&lt;/iframe&gt;&lt;/p&gt;
- Copy the course to a new course and ensure that all of the links now point to the new media file that was created in the course
- Do an export/import and ensure the same
- If you're feeling brave, do this while importing old quizzes as new quizzes (if not, we can test this with quizzes when I push the change into quizzes.  I have tested this and it is working for me.)