### PR TITLE
Prevent crashing with missing class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_link_migrator (1.0.7)
+    canvas_link_migrator (1.0.8)
       activesupport
       addressable
       nokogiri
@@ -20,25 +20,25 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.2.3)
     diff-lcs (1.5.1)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    mini_portile2 (2.8.5)
-    minitest (5.22.0)
-    nokogiri (1.15.5)
+    mini_portile2 (2.8.6)
+    minitest (5.22.3)
+    nokogiri (1.16.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.15.5-aarch64-linux)
+    nokogiri (1.16.4-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.15.5-arm64-darwin)
+    nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-darwin)
+    nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-linux)
+    nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
-    public_suffix (5.0.4)
+    public_suffix (5.0.5)
     racc (1.7.3)
-    rack (2.2.8)
+    rack (2.2.9)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -51,7 +51,7 @@ GEM
     rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.0)
+    rspec-support (3.13.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
@@ -71,4 +71,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.5.3
+   2.5.9

--- a/canvas_link_migrator.gemspec
+++ b/canvas_link_migrator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "canvas_link_migrator"
-  spec.version       = "1.0.8"
+  spec.version       = "1.0.9"
   spec.authors       = ["Mysti Lilla", "James Logan", "Sarah Gerard", "Math Costa"]
   spec.email         = ["mysti@instructure.com", "james.logan@instructure.com", "sarah.gerard@instructure.com", "luis.oliveira@instructure.com"]
   spec.summary       = "Instructure gem for migrating Canvas style rich content"

--- a/lib/canvas_link_migrator/link_parser.rb
+++ b/lib/canvas_link_migrator/link_parser.rb
@@ -96,12 +96,15 @@ module CanvasLinkMigrator
 
       # Replace old style media anchor tags with iframes
       doc.search("a[id*='media_comment_']").each do |media_node|
+        next unless media_node["class"].match('instructure_inline_media_comment')
+
         media_node.name = "iframe"
         # smallest accepted size for iframe since we don't have the size available for these
         media_node["style"] = "width: 320px; height: 240px; display: inline-block;"
         media_node["title"] = media_node.text
         media_node.child&.remove
-        media_node["data-media-type"] = media_node["class"].match(/(audio|video)_comment/)[1]
+        media_type = media_node["class"].match(/(audio|video)/)&.[](1)
+        media_node["data-media-type"] = media_type if media_type
         media_node["src"] = media_node["href"]
         media_node.delete("href")
         media_node["allowfullscreen"] = "allowfullscreen"

--- a/lib/canvas_link_migrator/version.rb
+++ b/lib/canvas_link_migrator/version.rb
@@ -1,3 +1,3 @@
 module CanvasLinkMigrator
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end

--- a/spec/canvas_link_migrator/link_parser_spec.rb
+++ b/spec/canvas_link_migrator/link_parser_spec.rb
@@ -51,4 +51,17 @@ describe CanvasLinkMigrator::LinkParser do
       expect{ parser.convert_link(doc.at_css('a'), "href", "wiki_page", "migrationid", "") }.not_to raise_error
     end
   end
+
+  describe "convert" do
+    it "does not change media anchor tags into iframes if they don't have inline_media_comment in the class" do
+      doc = Nokogiri::HTML5.fragment(%Q(<p><a id="media_comment_m-5HHT5LqZqPf7qhEJ7PbKtehCiunxM4BB" class=" instructure_video_link instructure_file_link" title="00-Personal Intro.m4v" href="https://xu.instructure.com/courses/83206/files/12176377/download?wrap=1" target="" data-api-endpoint="https://xu.instructure.com/api/v1/courses/83206/files/12176377" data-api-returntype="File">Click here to watch personal introduction</a></p>))
+      parser.convert(doc.to_html, "type", "lookup_id", "field")
+      expect(doc.to_html).to match(%Q(<p><a id="media_comment_m-5HHT5LqZqPf7qhEJ7PbKtehCiunxM4BB" class=" instructure_video_link instructure_file_link" title="00-Personal Intro.m4v" href="https://xu.instructure.com/courses/83206/files/12176377/download?wrap=1" target="" data-api-endpoint="https://xu.instructure.com/api/v1/courses/83206/files/12176377" data-api-returntype="File">Click here to watch personal introduction</a></p>))
+    end
+
+    it "does not crash if it can't find a video/audio_comment class name" do
+      doc = Nokogiri::HTML5.fragment(%Q(<a id="media_comment_m-4uoGqVdEqXhpqu2ZMytHSy9XMV73aQ7E" class="instructure_inline_media_comment" data-media_comment_type="video" data-alt=""></a>))
+      expect{ parser.convert(doc.to_html, "type", "lookup_id", "field") }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
fixes LF-1550

Test plan
- In Canvas, create a link like <a id="media_comment_m-media_id" class=" instructure_video_link instructure_file_link" title="video.m4v" href="/courses/1/files/1/download?wrap=1">tag</a> in rich content
- Copy the course and verify it copies the page and the link looks correct after copy (except data media id, that was already broken, as far as I can tell)