### PR TITLE
Find media_id in src as well as data-media-id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_link_migrator (1.0.11)
+    canvas_link_migrator (1.0.12)
       activesupport
       addressable
       nokogiri

--- a/canvas_link_migrator.gemspec
+++ b/canvas_link_migrator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "canvas_link_migrator"
-  spec.version       = "1.0.11"
+  spec.version       = "1.0.12"
   spec.authors       = ["Mysti Lilla", "James Logan", "Sarah Gerard", "Math Costa"]
   spec.email         = ["mysti@instructure.com", "james.logan@instructure.com", "sarah.gerard@instructure.com", "luis.oliveira@instructure.com"]
   spec.summary       = "Instructure gem for migrating Canvas style rich content"

--- a/lib/canvas_link_migrator/link_resolver.rb
+++ b/lib/canvas_link_migrator/link_resolver.rb
@@ -248,8 +248,9 @@ module CanvasLinkMigrator
       elsif rel_path&.match(/\/media_attachments_iframe\/\d+/)
         # media attachment from another course or something
         rel_path
-      elsif node["data-media-id"].present?
-        file_id, uuid = @migration_id_converter.convert_attachment_media_id(node["data-media-id"])
+      elsif (file_id, uuid = @migration_id_converter.convert_attachment_media_id(node["data-media-id"]))
+        file_id ? media_attachment_iframe_url(file_id, uuid, node["data-media-type"]) : nil
+      elsif (file_id, uuid = @migration_id_converter.convert_attachment_media_id(rel_path.match(/media_objects(?:_iframe)?\/([^?.]+)/)&.[](1)))
         file_id ? media_attachment_iframe_url(file_id, uuid, node["data-media-type"]) : nil
       else
         node.delete("class")

--- a/lib/canvas_link_migrator/version.rb
+++ b/lib/canvas_link_migrator/version.rb
@@ -1,3 +1,3 @@
 module CanvasLinkMigrator
-  VERSION = "1.0.11"
+  VERSION = "1.0.12"
 end


### PR DESCRIPTION
refs LF-1549

Test plan
- Have a link in rich content that looks like <iframe title="media file" src="media_objects_iframe/media_id?type=video"  data-media-id="undefined"></iframe>
- Ensure it points to a valid media object that doesn't have an attachment in the course
- Copy the course and ensure the link comes over as a media attachment correctly