### PR TITLE
Add verifiers to links when available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_link_migrator (1.0.9)
+    canvas_link_migrator (1.0.10)
       activesupport
       addressable
       nokogiri
@@ -20,24 +20,24 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.2.3)
     diff-lcs (1.5.1)
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     mini_portile2 (2.8.6)
-    minitest (5.22.3)
-    nokogiri (1.16.4)
+    minitest (5.23.1)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.4-aarch64-linux)
+    nokogiri (1.16.5-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.4-arm64-darwin)
+    nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.4-x86_64-darwin)
+    nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.4-x86_64-linux)
+    nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     public_suffix (5.0.5)
-    racc (1.7.3)
+    racc (1.8.0)
     rack (2.2.9)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -48,7 +48,7 @@ GEM
     rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
@@ -71,4 +71,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.5.9
+   2.5.10

--- a/canvas_link_migrator.gemspec
+++ b/canvas_link_migrator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "canvas_link_migrator"
-  spec.version       = "1.0.9"
+  spec.version       = "1.0.10"
   spec.authors       = ["Mysti Lilla", "James Logan", "Sarah Gerard", "Math Costa"]
   spec.email         = ["mysti@instructure.com", "james.logan@instructure.com", "sarah.gerard@instructure.com", "luis.oliveira@instructure.com"]
   spec.summary       = "Instructure gem for migrating Canvas style rich content"

--- a/lib/canvas_link_migrator/link_parser.rb
+++ b/lib/canvas_link_migrator/link_parser.rb
@@ -19,7 +19,6 @@
 
 require "nokogiri"
 require "digest"
-require "addressable"
 
 module CanvasLinkMigrator
   class LinkParser
@@ -144,12 +143,7 @@ module CanvasLinkMigrator
         url.gsub!("%24#{ref}%24", "$#{ref}$")
       end
 
-      begin
-        result = parse_url(url, node, attr)
-      rescue Addressable::URI::InvalidURIError
-        return
-      end
-
+      result = parse_url(url, node, attr)
       if result[:resolved]
         # resolved, just replace and carry on
         new_url = result[:new_url] || url

--- a/lib/canvas_link_migrator/resource_map_service.rb
+++ b/lib/canvas_link_migrator/resource_map_service.rb
@@ -89,7 +89,19 @@ module CanvasLinkMigrator
     end
 
     def convert_attachment_migration_id(migration_id)
-      resources.dig("files", migration_id, "destination", "id")
+      resources.dig("files", migration_id, "destination")&.slice("id", "uuid")&.values
+    end
+
+    def media_map
+      @media_map ||= resources["files"].each_with_object({}) do |(_mig_id, file), map|
+        media_id = file.dig("destination", "media_entry_id")
+        next unless media_id
+        map[media_id] = file
+      end
+    end
+
+    def convert_attachment_media_id(media_id)
+      media_map.dig(media_id, "destination")&.slice("id", "uuid")&.values
     end
 
     def convert_migration_id(type, migration_id)
@@ -105,18 +117,6 @@ module CanvasLinkMigrator
 
     def lookup_attachment_by_migration_id(migration_id)
       resources.dig("files", migration_id, "destination")
-    end
-
-    def media_map
-      @media_map ||= resources["files"].each_with_object({}) do |(_mig_id, file), map|
-        media_id = file.dig("destination", "media_entry_id")
-        next unless media_id
-        map[media_id] = file
-      end
-    end
-
-    def lookup_attachment_by_media_id(media_id)
-      media_map.dig(media_id, "destination")
     end
   end
 end

--- a/lib/canvas_link_migrator/version.rb
+++ b/lib/canvas_link_migrator/version.rb
@@ -1,3 +1,3 @@
 module CanvasLinkMigrator
-  VERSION = "1.0.9"
+  VERSION = "1.0.10"
 end

--- a/spec/canvas_link_migrator/imported_html_converter_spec.rb
+++ b/spec/canvas_link_migrator/imported_html_converter_spec.rb
@@ -75,7 +75,7 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
         it "converts data-download-url for files without appending a context" do
           html, bad_links = subject
           expect(html).to eq(
-            "<img src=\"#{@path}files/5/download?download_frd=1\" alt=\"\" data-inst-icon-maker-icon=\"true\" data-download-url=\"/files/5/download?download_frd=1&icon_maker_icon=1\">"
+            "<img src=\"#{@path}files/5/download?download_frd=1&verifier=u5\" alt=\"\" data-inst-icon-maker-icon=\"true\" data-download-url=\"/files/5/download?download_frd=1&icon_maker_icon=1&verifier=u5\">"
           )
           expect(bad_links).to be_nil
         end
@@ -83,7 +83,7 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
 
       it "finds an attachment by migration id" do
         test_string = %{<p>This is an image: <br /><img src="%24CANVAS_OBJECT_REFERENCE%24/attachments/F" alt=":(" /></p>}
-        expect(@converter.convert_exported_html(test_string)).to eq([%{<p>This is an image: <br><img src="#{@path}files/6/preview" alt=":("></p>}, nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%{<p>This is an image: <br><img src="#{@path}files/6/preview?verifier=u6" alt=":("></p>}, nil])
       end
 
       it "leaves relative user attachments alone" do
@@ -106,20 +106,20 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
         expect(bad_links[0]).to include({ link_type: :file, missing_url: "/courses/2/file_contents/course%20files/test.png" })
 
         expect(@converter.link_resolver).to receive(:attachment_path_id_lookup).twice.and_call_original
-        expect(@converter.convert_exported_html(test_string)).to eq([%{<p>This is an image: <br><img src="#{@path}files/5/preview" alt=":("></p>}, nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%{<p>This is an image: <br><img src="#{@path}files/5/preview?verifier=u5" alt=":("></p>}, nil])
       end
 
       it "finds an attachment by a path with a space" do
         test_string = %(<img src="subfolder/with%20a%20space/test.png" alt="nope" />)
-        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/6/preview" alt="nope">), nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/6/preview?verifier=u6" alt="nope">), nil])
 
         test_string = %(<img src="subfolder/with+a+space/test.png" alt="nope" />)
-        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/6/preview" alt="nope">), nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/6/preview?verifier=u6" alt="nope">), nil])
       end
 
       it "finds an attachment even if the link has an extraneous folder" do
         test_string = %(<img src="anotherfolder/subfolder/test.png" alt="nope" />)
-        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/7/preview" alt="nope">), nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/7/preview?verifier=u7" alt="nope">), nil])
       end
 
       it "finds an attachment by path if capitalization is different" do
@@ -127,18 +127,18 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
         expect(@converter.link_resolver).to receive(:attachment_path_id_lookup).twice.and_return({ "subfolder/withcapital/test.png" => "F" })
 
         test_string = %(<img src="subfolder/WithCapital/TEST.png" alt="nope" />)
-        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/6/preview" alt="nope">), nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/6/preview?verifier=u6" alt="nope">), nil])
       end
 
       it "finds an attachment with query params" do
         test_string = %(<img src="%24IMS_CC_FILEBASE%24/test.png?canvas_customaction=1&canvas_qs_customparam=1" alt="nope" />)
-        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/5/customaction?customparam=1" alt="nope">), nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/5/customaction?verifier=u5&customparam=1" alt="nope">), nil])
 
         test_string = %(<img src="%24IMS_CC_FILEBASE%24/test.png?canvas_qs_customparam2=3" alt="nope" />)
-        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/5/preview?customparam2=3" alt="nope">), nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/5/preview?verifier=u5&customparam2=3" alt="nope">), nil])
 
         test_string = %(<img src="%24IMS_CC_FILEBASE%24/test.png?notarelevantparam" alt="nope" />)
-        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/5/preview" alt="nope">), nil])
+        expect(@converter.convert_exported_html(test_string)).to eq([%(<img src="#{@path}files/5/preview?verifier=u5" alt="nope">), nil])
       end
     end
 
@@ -221,9 +221,9 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
 
       expected_string = <<~HTML.strip
         <p>
-          with media object url: <iframe id="media_comment_m-stuff" class="instructure_inline_media_comment video_comment" style="width: 320px; height: 240px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/5?embedded=true&amp;type=video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-stuff"></iframe>
-          with file content url: <iframe id="media_comment_0_bq09qam2" class="instructure_inline_media_comment video_comment" style="width: 320px; height: 240px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/6?embedded=true&amp;type=video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="0_bq09qam2"></iframe>
-          with mediahref url: <iframe data-media-type="video" src="/media_attachments_iframe/9?type=video&embedded=true" data-media-id="m-yodawg"></iframe>
+          with media object url: <iframe id="media_comment_m-stuff" class="instructure_inline_media_comment video_comment" style="width: 320px; height: 240px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/5?embedded=true&amp;type=video&amp;verifier=u5" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-stuff"></iframe>
+          with file content url: <iframe id="media_comment_0_bq09qam2" class="instructure_inline_media_comment video_comment" style="width: 320px; height: 240px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/6?embedded=true&amp;type=video&amp;verifier=u6" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="0_bq09qam2"></iframe>
+          with mediahref url: <iframe data-media-type="video" src="/media_attachments_iframe/9?embedded=true&type=video&verifier=u9" data-media-id="m-yodawg"></iframe>
         </p>
       HTML
 
@@ -272,8 +272,8 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
       HTML
       expected_string = <<~HTML.strip
         <p>
-          with wrong file in href: <iframe class="instructure_inline_media_comment video_comment" id="media_comment_m-stuff" style="width: 320px; height: 240px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/5?embedded=true&amp;type=video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-stuff"></iframe><br><br>
-          with no href: <iframe class="instructure_inline_media_comment video_comment" id="media_comment_m-stuff" style="width: 320px; height: 240px; display: inline-block;" title="" data-media-type="video" src="/media_attachments_iframe/5?embedded=true&amp;type=video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-stuff"></iframe><br><br>
+          with wrong file in href: <iframe class="instructure_inline_media_comment video_comment" id="media_comment_m-stuff" style="width: 320px; height: 240px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/5?embedded=true&amp;type=video&amp;verifier=u5" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-stuff"></iframe><br><br>
+          with no href: <iframe class="instructure_inline_media_comment video_comment" id="media_comment_m-stuff" style="width: 320px; height: 240px; display: inline-block;" title="" data-media-type="video" src="/media_attachments_iframe/5?embedded=true&amp;type=video&amp;verifier=u5" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-stuff"></iframe><br><br>
         </p>
       HTML
       expect(@converter.convert_exported_html(test_string)).to eq([expected_string, nil])
@@ -281,33 +281,33 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
 
     it "converts old RCE media object iframes" do
       test_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_objects_iframe/m-lolcat?type=video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat"></iframe>)
-      replacement_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/8?embedded=true&amp;type=video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat"></iframe>)
+      replacement_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/8?embedded=true&amp;type=video&amp;verifier=u8" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat"></iframe>)
       expect(@converter.convert_exported_html(test_string)).to eq([replacement_string, nil])
     end
 
     it "handles and repair half broken new RCE media iframes" do
       test_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" src="%24IMS_CC_FILEBASE%24/#" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat"></iframe>)
-      repaired_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/8?embedded=true&amp;type=video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat"></iframe>)
+      repaired_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" src="/media_attachments_iframe/8?embedded=true&amp;type=video&amp;verifier=u8" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat"></iframe>)
       expect(@converter.convert_exported_html(test_string)).to eq([repaired_string, nil])
     end
 
     it "converts source tags to RCE media iframes" do
       test_string = %(<video style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat"><source src="/media_objects_iframe/m-lolcat?type=video" data-media-id="m-lolcat" data-media-type="video"></video>)
-      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat" src="/media_attachments_iframe/8?embedded=true&amp;type=video"></iframe>)
+      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-lolcat" src="/media_attachments_iframe/8?embedded=true&amp;type=video&amp;verifier=u8"></iframe>)
       expect(@converter.convert_exported_html(test_string)).to eq([converted_string, nil])
 
       test_string = %(<audio style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-yodawg"><source src="/media_objects_iframe/m-yodawg?type=audio" data-media-id="m-yodawg" data-media-type="audio"></audio>)
-      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-yodawg" src="/media_attachments_iframe/9?embedded=true&amp;type=audio"></iframe>)
+      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-yodawg" src="/media_attachments_iframe/9?embedded=true&amp;type=audio&amp;verifier=u9"></iframe>)
       expect(@converter.convert_exported_html(test_string)).to eq([converted_string, nil])
     end
 
     it "converts source tags to RCE media attachment iframes" do
       test_string = %(<video style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-stuff"><source src="$IMS-CC-FILEBASE$/subfolder/with a space/yodawg.mov?canvas_=1&canvas_qs_type=video&canvas_qs_amp=&canvas_qs_embedded=true&media_attachment=true" data-media-id="m-stuff" data-media-type="video"></video>)
-      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-yodawg" src="/media_attachments_iframe/9?embedded=true&amp;type=video"></iframe>)
+      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-yodawg" src="/media_attachments_iframe/9?embedded=true&amp;type=video&amp;verifier=u9"></iframe>)
       expect(@converter.convert_exported_html(test_string)).to eq([converted_string, nil])
 
       test_string = %(<audio style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-stuff"><source src="$IMS-CC-FILEBASE$/lolcat.mp3?canvas_=1&canvas_qs_type=audio&canvas_qs_amp=&canvas_qs_embedded=true&media_attachment=true" data-media-id="m-stuff" data-media-type="audio"></video>)
-      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-lolcat" src="/media_attachments_iframe/8?embedded=true&amp;type=audio"></iframe>)
+      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-lolcat" src="/media_attachments_iframe/8?embedded=true&amp;type=audio&amp;verifier=u8"></iframe>)
       expect(@converter.convert_exported_html(test_string)).to eq([converted_string, nil])
     end
 
@@ -323,11 +323,11 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
 
     it "converts course copy style media attachmet iframe links" do
       test_string = %(<video style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-yodawg"><source src="$CANVAS_COURSE_REFERENCE$/file_ref/I?media_attachment=true&type=video" data-media-id="m-yodawg" data-media-type="video"></video>)
-      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-yodawg" src="/media_attachments_iframe/9?type=video&embedded=true"></iframe>)
+      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="video" allowfullscreen="allowfullscreen" allow="fullscreen" data-media-id="m-yodawg" src="/media_attachments_iframe/9?embedded=true&type=video&verifier=u9"></iframe>)
       expect(@converter.convert_exported_html(test_string)).to eq([converted_string, nil])
 
       test_string = %(<audio style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-lolcat"><source src="$CANVAS_COURSE_REFERENCE$/file_ref/H?media_attachment=true&type=audio" data-media-id="m-lolcat" data-media-type="audio"></audio>)
-      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-lolcat" src="/media_attachments_iframe/8?type=audio&embedded=true"></iframe>)
+      converted_string = %(<iframe style="width: 400px; height: 225px; display: inline-block;" title="this is a media comment" data-media-type="audio" data-media-id="m-lolcat" src="/media_attachments_iframe/8?embedded=true&type=audio&verifier=u8"></iframe>)
       expect(@converter.convert_exported_html(test_string)).to eq([converted_string, nil])
     end
 

--- a/spec/canvas_link_migrator/link_resolver_spec.rb
+++ b/spec/canvas_link_migrator/link_resolver_spec.rb
@@ -48,25 +48,25 @@ describe CanvasLinkMigrator::LinkResolver do
     it "converts file_ref urls" do
       link = { link_type: :file_ref, migration_id: "F" }
       resolver.resolve_link!(link)
-      expect(link[:new_value]).to eq("/courses/2/files/6/preview")
+      expect(link[:new_value]).to eq("/courses/2/files/6/preview?verifier=u6")
     end
 
     it "does not suffix /preview to target blank links" do
       link = { link_type: :file_ref, target_blank: true, migration_id: "F" }
       resolver.resolve_link!(link)
-      expect(link[:new_value]).to eq("/courses/2/files/6")
+      expect(link[:new_value]).to eq("/courses/2/files/6?verifier=u6")
     end
 
     it "converts attachment urls" do
       link = { link_type: :object, type: "attachments", migration_id: "E", query: "?foo=bar" }
       resolver.resolve_link!(link)
-      expect(link[:new_value]).to eq("/courses/2/files/5/preview")
+      expect(link[:new_value]).to eq("/courses/2/files/5/preview?verifier=u5")
     end
 
     it "converts media_attachments_iframe urls" do
       link = { link_type: :object, type: "media_attachments_iframe", migration_id: "F", query: "?foo=bar" }
       resolver.resolve_link!(link)
-      expect(link[:new_value]).to eq("/media_attachments_iframe/6?foo=bar")
+      expect(link[:new_value]).to eq("/media_attachments_iframe/6?foo=bar&verifier=u6")
     end
 
     it "converts discussion_topic links" do

--- a/spec/fixtures/canvas_resource_map.json
+++ b/spec/fixtures/canvas_resource_map.json
@@ -50,49 +50,60 @@
       "E": {
         "destination": {
           "id": "5",
-          "media_entry_id": "m-stuff"
+          "media_entry_id": "m-stuff",
+          "uuid": "u5"
         },
         "source": {
           "id": "3",
-          "media_entry_id": "m-stuff"
+          "media_entry_id": "m-stuff",
+          "uuid": "u3"
         }
       },
       "F": {
         "destination": {
           "id": "6",
-          "media_entry_id": "0_bq09qam2"
+          "media_entry_id": "0_bq09qam2",
+          "uuid": "u6"
         },
         "source": {
           "id": "4",
-          "media_entry_id": "0_bq09qam2"
+          "media_entry_id": "0_bq09qam2",
+          "uuid": "u4"
         }
       },
       "G": {
         "destination": {
-          "id": "7"
+          "id": "7",
+          "uuid": "u7"
         },
         "source": {
-          "id": "2"
+          "id": "2",
+          "uuid": "u2"
         }
       },
       "H": {
         "destination": {
           "id": "8",
-          "media_entry_id": "m-lolcat"
+          "media_entry_id": "m-lolcat",
+          "uuid": "u8"
+
         },
         "source": {
           "id": "3",
-          "media_entry_id": "m-lolcat"
+          "media_entry_id": "m-lolcat",
+          "uuid": "u3"
         }
       },
       "I": {
         "destination": {
           "id": "9",
-          "media_entry_id": "m-yodawg"
+          "media_entry_id": "m-yodawg",
+          "uuid": "u9"
         },
         "source": {
           "id": "4",
-          "media_entry_id": "m-yodawg"
+          "media_entry_id": "m-yodawg",
+          "uuid": "u4"
         }
       }
     },


### PR DESCRIPTION
refs RCX-1948

Test plan
- Test with https://gerrit.instructure.com/c/canvas-lms/+/349361
- Set up the CanvasLinkMigrator in Canvas and NewQuizzes
- Set up links to all kinds of files in a Canvas object and a Old Quiz object
- Copy the course and use the old quiz to new quiz migration option
- Ensure that the copied quizzes have verifiers on the links (if the feature flag is on) and the Canvas object doesn't
- Turn off the flag and ensure you don't get verifiers on the New Quiz objects