### PR TITLE
Convert non-media iframes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_link_migrator (1.0.12)
+    canvas_link_migrator (1.0.13)
       activesupport
       addressable
       nokogiri

--- a/canvas_link_migrator.gemspec
+++ b/canvas_link_migrator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "canvas_link_migrator"
-  spec.version       = "1.0.12"
+  spec.version       = "1.0.13"
   spec.authors       = ["Mysti Lilla", "James Logan", "Sarah Gerard", "Math Costa"]
   spec.email         = ["mysti@instructure.com", "james.logan@instructure.com", "sarah.gerard@instructure.com", "luis.oliveira@instructure.com"]
   spec.summary       = "Instructure gem for migrating Canvas style rich content"

--- a/lib/canvas_link_migrator/link_parser.rb
+++ b/lib/canvas_link_migrator/link_parser.rb
@@ -19,7 +19,6 @@
 
 require "nokogiri"
 require "digest"
-require "byebug"
 
 module CanvasLinkMigrator
   class LinkParser

--- a/lib/canvas_link_migrator/link_parser.rb
+++ b/lib/canvas_link_migrator/link_parser.rb
@@ -19,6 +19,7 @@
 
 require "nokogiri"
 require "digest"
+require "byebug"
 
 module CanvasLinkMigrator
   class LinkParser
@@ -232,7 +233,7 @@ module CanvasLinkMigrator
       elsif url =~ %r{\$IMS(?:-|_)CC(?:-|_)FILEBASE\$/(.*)}
         rel_path = URI::DEFAULT_PARSER.unescape($1)
         if (attr == "href" && node["class"]&.include?("instructure_inline_media_comment")) ||
-           (attr == "src" && ["iframe", "source"].include?(node.name))
+           (attr == "src" && ["iframe", "source"].include?(node.name) && (node["data-media-id"] || node["data-media-type"] || node[attr].include?("media_objects_iframe")))
           unresolved(:media_object, rel_path: rel_path)
         else
           unresolved(:file, rel_path: rel_path)

--- a/lib/canvas_link_migrator/link_parser.rb
+++ b/lib/canvas_link_migrator/link_parser.rb
@@ -232,7 +232,7 @@ module CanvasLinkMigrator
       elsif url =~ %r{\$IMS(?:-|_)CC(?:-|_)FILEBASE\$/(.*)}
         rel_path = URI::DEFAULT_PARSER.unescape($1)
         if (attr == "href" && node["class"]&.include?("instructure_inline_media_comment")) ||
-           (attr == "src" && ["iframe", "source"].include?(node.name) && (node["data-media-id"] || node["data-media-type"] || node[attr].include?("media_objects_iframe")))
+           (attr == "src" && ["iframe", "source"].include?(node.name) && (node["data-media-id"] || node["data-media-type"]))
           unresolved(:media_object, rel_path: rel_path)
         else
           unresolved(:file, rel_path: rel_path)

--- a/lib/canvas_link_migrator/version.rb
+++ b/lib/canvas_link_migrator/version.rb
@@ -1,3 +1,3 @@
 module CanvasLinkMigrator
-  VERSION = "1.0.12"
+  VERSION = "1.0.13"
 end

--- a/spec/canvas_link_migrator/imported_html_converter_spec.rb
+++ b/spec/canvas_link_migrator/imported_html_converter_spec.rb
@@ -400,5 +400,16 @@ describe CanvasLinkMigrator::ImportedHtmlConverter do
       test_string = '<p><a href="#anchor_ref">ref</a></p>'
       expect(@converter.convert_exported_html(test_string)).to eq([test_string, nil])
     end
+
+    it "converts iframe srcs that point to non-media files" do
+      test_string = <<~HTML
+      <p><iframe style="width: 100%; height: 100vh; border: none;" src="$IMS-CC-FILEBASE$/subfolder/test.png?canvas_download=1"></iframe></p>
+      HTML
+      converted_string = <<~HTML
+      <p><iframe style="width: 100%; height: 100vh; border: none;" src="/courses/2/files/7/download?verifier=u7"></iframe></p>
+      HTML
+      html = @converter.convert_exported_html(test_string)
+      expect(html[0]).to eq converted_string
+    end
   end
 end


### PR DESCRIPTION
    fixes RCX-2117
    
    Test Plan:
    - Have an iframe with a src pointing to a course document
    * Ex: <iframe src="/courses/33/files/1422/download" style="width: 100%; height: 100vh; border: none;">
    * Or check the ticket, go to the linked course and select a page, go to Edit and copy that form of html
    - Export course
    - Import package into course
    * Verify iframe has been properly migrated
    * This scenario does not occur with a course copy

